### PR TITLE
Add introduction-to-ripqp

### DIFF
--- a/_data/docs.json
+++ b/_data/docs.json
@@ -62,5 +62,13 @@
     "date": "2022-06-07",
     "tags": ["introduction", "benchmark"],
     "pkgs": ["BenchmarkProfiles"]
+  },
+  {
+    "title": "Introduction to RipQP",
+    "repo": "introduction-to-ripqp",
+    "short": "A package to optimize linear and quadratic problems in QuadraticModel format using a regularized interior-point method.",
+    "date": "2022-06-25",
+    "tags": ["introduction", "quadratic", "regularized", "solver"],
+    "pkgs": ["QuadraticModels", "LinearAlgebra", "SparseMatricesCOO", "RipQP", "QPSReader", "QuadraticModels", "DelimitedFiles", "MatrixMarket", "TimerOutputs"]
   }
 ]


### PR DESCRIPTION
Tutorial new location: [jso-docs.github.io/introduction-to-ripqp](https://jso-docs.github.io/introduction-to-ripqp/)
Tutorial old location: https://juliasmoothoptimizers.github.io/RipQP.jl/stable/tutorial/
RipQP PR: https://github.com/JuliaSmoothOptimizers/RipQP.jl/pull/201