### PR TITLE
Updates from JSOTutorials - CompatHelper: bump compat for ADNLPModels to 0.7 for package create-a-manual-model

### DIFF
--- a/tutorials/create-a-manual-model/index.md
+++ b/tutorials/create-a-manual-model/index.md
@@ -10,7 +10,7 @@
 [![ManualNLPModels 0.1.5](https://img.shields.io/badge/ManualNLPModels-0.1.5-8b0000?style=flat-square&labelColor=cb3c33)](https://juliasmoothoptimizers.github.io/ManualNLPModels.jl/stable/)
 [![NLPModelsJuMP 0.12.1](https://img.shields.io/badge/NLPModelsJuMP-0.12.1-8b0000?style=flat-square&labelColor=cb3c33)](https://juliasmoothoptimizers.github.io/NLPModelsJuMP.jl/stable/)
 ![BenchmarkTools 1.3.2](https://img.shields.io/badge/BenchmarkTools-1.3.2-000?style=flat-square&labelColor=999)
-[![ADNLPModels 0.6.2](https://img.shields.io/badge/ADNLPModels-0.6.2-8b0000?style=flat-square&labelColor=cb3c33)](https://juliasmoothoptimizers.github.io/ADNLPModels.jl/stable/)
+[![ADNLPModels 0.7.0](https://img.shields.io/badge/ADNLPModels-0.7.0-8b0000?style=flat-square&labelColor=cb3c33)](https://juliasmoothoptimizers.github.io/ADNLPModels.jl/stable/)
 ![JuMP 1.12.0](https://img.shields.io/badge/JuMP-1.12.0-000?style=flat-square&labelColor=999)
 [![JSOSolvers 0.11.0](https://img.shields.io/badge/JSOSolvers-0.11.0-006400?style=flat-square&labelColor=389826)](https://juliasmoothoptimizers.github.io/JSOSolvers.jl/stable/)
 
@@ -139,14 +139,14 @@ end
 ```
 
 ```plaintext
-BenchmarkTools.Trial: 1844 samples with 1 evaluation.
- Range (min … max):  2.374 ms …   7.601 ms  ┊ GC (min … max): 0.00% … 58.28%
- Time  (median):     2.519 ms               ┊ GC (median):    0.00%
- Time  (mean ± σ):   2.706 ms ± 876.791 μs  ┊ GC (mean ± σ):  5.78% ± 11.17%
+BenchmarkTools.Trial: 1999 samples with 1 evaluation.
+ Range (min … max):  2.291 ms …   5.625 ms  ┊ GC (min … max): 0.00% … 45.53%
+ Time  (median):     2.351 ms               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   2.498 ms ± 514.270 μs  ┊ GC (mean ± σ):  3.50% ±  8.91%
 
-  █▇▇▆▄▂                                                       
-  ██████▇▆▅▄▄▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▇▇▇██ █
-  2.37 ms      Histogram: log(frequency) by time      7.21 ms <
+  ██▅▆▂         ▁▁                                             
+  █████▇▄▄▅▄▃▄▄▁███▇▄▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▃▃▆▅▆▅▆▆▅▄▄▆▆ █
+  2.29 ms      Histogram: log(frequency) by time      5.16 ms <
 
  Memory estimate: 1.73 MiB, allocs estimate: 2655.
 ```
@@ -165,16 +165,16 @@ end
 ```
 
 ```plaintext
-BenchmarkTools.Trial: 3 samples with 1 evaluation.
- Range (min … max):  1.647 s …   1.730 s  ┊ GC (min … max): 12.81% … 14.83%
- Time  (median):     1.707 s              ┊ GC (median):    15.03%
- Time  (mean ± σ):   1.695 s ± 42.971 ms  ┊ GC (mean ± σ):  14.34% ±  1.32%
+BenchmarkTools.Trial: 17 samples with 1 evaluation.
+ Range (min … max):  299.460 ms … 307.731 ms  ┊ GC (min … max): 0.00% … 0.60%
+ Time  (median):     301.345 ms               ┊ GC (median):    0.60%
+ Time  (mean ± σ):   301.179 ms ±   1.899 ms  ┊ GC (mean ± σ):  0.39% ± 0.30%
 
-  █                                        █              █  
-  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
-  1.65 s         Histogram: frequency by time        1.73 s <
+  █            ██                                                
+  █▁▁▆▆▁▁▁▁▁▁▁▁██▆▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆ ▁
+  299 ms           Histogram: frequency by time          308 ms <
 
- Memory estimate: 448.57 MiB, allocs estimate: 6426996.
+ Memory estimate: 30.52 MiB, allocs estimate: 3786.
 ```
 
 
@@ -206,14 +206,14 @@ end
 ```
 
 ```plaintext
-BenchmarkTools.Trial: 32 samples with 1 evaluation.
- Range (min … max):  151.953 ms … 172.083 ms  ┊ GC (min … max): 7.88% … 11.86%
- Time  (median):     157.138 ms               ┊ GC (median):    7.65%
- Time  (mean ± σ):   160.681 ms ±   6.355 ms  ┊ GC (mean ± σ):  8.22% ±  1.69%
+BenchmarkTools.Trial: 33 samples with 1 evaluation.
+ Range (min … max):  144.085 ms … 158.153 ms  ┊ GC (min … max): 4.32% … 8.17%
+ Time  (median):     151.985 ms               ┊ GC (median):    5.21%
+ Time  (mean ± σ):   152.054 ms ±   4.129 ms  ┊ GC (mean ± σ):  5.85% ± 1.51%
 
-              ▁█▁               ▁                                
-  ▆▁▆▁▆▆▆▆▁▁▁▆███▆▆▁▁▁▁▁▁▁▁▆▁▁▁▁█▁▁▆▁▁▁▁▆▁▆▁▆▁▆▆▁▁▆▁▁▆▁▁▁▁▆▁▆▆▆ ▁
-  152 ms           Histogram: frequency by time          172 ms <
+  ▃                    ▃ ▃█   ▃        ▃           ▃    █   ▃ ▃  
+  █▁▁▇▁▁▁▁▁▇▁▁▁▇▁▁▁▁▁▁▁█▁██▇▁▁█▁▁▇▁▁▇▁▇█▇▁▁▁▁▁▁▁▁▇▁█▇▁▇▁█▁▁▁█▁█ ▁
+  144 ms           Histogram: frequency by time          158 ms <
 
  Memory estimate: 98.01 MiB, allocs estimate: 436900.
 ```
@@ -232,13 +232,13 @@ using NLPModels
 
 ```plaintext
 BenchmarkTools.Trial: 10000 samples with 1 evaluation.
- Range (min … max):  12.300 μs …  7.114 ms  ┊ GC (min … max): 0.00% … 88.44%
- Time  (median):     14.501 μs              ┊ GC (median):    0.00%
- Time  (mean ± σ):   16.550 μs ± 95.792 μs  ┊ GC (mean ± σ):  7.58% ±  1.33%
+ Range (min … max):  13.100 μs …  3.577 ms  ┊ GC (min … max): 0.00% … 91.27%
+ Time  (median):     14.100 μs              ┊ GC (median):    0.00%
+ Time  (mean ± σ):   15.244 μs ± 47.394 μs  ┊ GC (mean ± σ):  4.14% ±  1.34%
 
-      ▆▄▄▆▄█▂▁▁▄                                               
-  ▃▅▇███████████▇▇▆▆▇▅▅▅▅▄▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂ ▄
-  12.3 μs         Histogram: frequency by time        25.4 μs <
+      ▃▆██▇▅▅▂▁                                                
+  ▂▃▅███████████▇▅▅▄▄▄▃▃▃▄▄▄▄▅▄▄▃▃▃▃▃▃▃▃▂▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂ ▄
+  13.1 μs         Histogram: frequency by time        19.3 μs <
 
  Memory estimate: 18.19 KiB, allocs estimate: 8.
 ```
@@ -251,14 +251,14 @@ adnlp = ADNLPModel(β -> myfun(β, X, y), zeros(p + 1))
 ```
 
 ```plaintext
-BenchmarkTools.Trial: 1156 samples with 1 evaluation.
- Range (min … max):  4.262 ms …   9.244 ms  ┊ GC (min … max): 0.00% … 50.32%
- Time  (median):     4.284 ms               ┊ GC (median):    0.00%
- Time  (mean ± σ):   4.323 ms ± 357.070 μs  ┊ GC (mean ± σ):  0.60% ±  3.75%
+BenchmarkTools.Trial: 1084 samples with 1 evaluation.
+ Range (min … max):  4.565 ms …   6.848 ms  ┊ GC (min … max): 0.00% … 29.84%
+ Time  (median):     4.580 ms               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   4.611 ms ± 181.170 μs  ┊ GC (mean ± σ):  0.29% ±  2.42%
 
-     ▅██▅▂                                                     
-  ▃▄██████▇▅▄▃▃▂▂▁▂▂▂▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▂▂▂▂▃▃▂▂ ▃
-  4.26 ms         Histogram: frequency by time        4.49 ms <
+    ██▄                                                        
+  ▃█████▅▃▂▂▂▂▂▂▂▁▂▁▁▂▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▃▃▃▃▂▂ ▃
+  4.57 ms         Histogram: frequency by time        4.79 ms <
 
  Memory estimate: 471.91 KiB, allocs estimate: 42.
 ```
@@ -286,13 +286,13 @@ jumpnlp = MathOptNLPModel(model)
 
 ```plaintext
 BenchmarkTools.Trial: 10000 samples with 1 evaluation.
- Range (min … max):  225.605 μs … 821.420 μs  ┊ GC (min … max): 0.00% … 0.00%
- Time  (median):     232.406 μs               ┊ GC (median):    0.00%
- Time  (mean ± σ):   233.738 μs ±   9.509 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+ Range (min … max):  205.299 μs … 434.699 μs  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     208.300 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   209.617 μs ±   4.853 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 
-              ▁██▃                                               
-  ▁▂▄▇▆▆▄▃▁▂▂▆████▆▄▃▃▂▂▂▂▂▂▂▃▂▃▂▂▂▂▁▁▁▂▂▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
-  226 μs           Histogram: frequency by time          255 μs <
+     ▁▃█▅▆▅ ▁                                                    
+  ▂▃▄████████▆▇▅▅▄▄▄▄▄▃▃▃▃▃▃▃▂▂▂▃▂▃▂▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂ ▃
+  205 μs           Histogram: frequency by time          227 μs <
 
  Memory estimate: 496 bytes, allocs estimate: 1.
 ```


### PR DESCRIPTION
Updates from jsotutorials-push-16aa71d164d516a0725cd75caeeba8e6ad376ade