### PR TITLE
inspiring computing podcast episode added

### DIFF
--- a/news-and-blogposts/2024/2024-06-14-inspiring-computing-podcast.md
+++ b/news-and-blogposts/2024/2024-06-14-inspiring-computing-podcast.md
@@ -1,48 +1,16 @@
-@def title = "Behind the Code: JuliaSmoothOptimizers Featured on Inspiring Computing Podcast!"
-@def rss_description = "Abel Soares Siqueira shares insights about Julia Smooth Optimizers and Research Software Engineering on the Inspiring Computing podcast."
+@def title = "Abel Soares Siqueira on Inspiring Computing Podcast"
+@def rss_description = "Abel Soares Siqueira discusses Julia Smooth Optimizers on the Inspiring Computing podcast."
 
-# Behind the Code: JuliaSmoothOptimizers Featured on Inspiring Computing Podcast!
+# Abel Soares Siqueira on Inspiring Computing Podcast
 
-Excitement is in the air as JuliaSmoothOptimizers takes center stage on the [Inspiring Computing podcast](https://www.buzzsprout.com/2107763/15200323)!
-We're thrilled to announce that Abel Soares Siqueira, one of our core contributors, was featured in an engaging episode where he shares the story behind JSO and the power of Julia in scientific computing.
+Abel Soares Siqueira was recently featured on the [Inspiring Computing podcast](https://www.buzzsprout.com/2107763/episodes/15200323), where he discussed his work on JuliaSmoothOptimizers and his role as a research software engineer at the [Netherlands eScience Center](https://www.esciencecenter.nl/).
 
-In this captivating 56-minute conversation titled "Behind the Code: Abel's Contributions to Julia Smooth Optimizers and Research Software Engineering," Abel takes listeners on a journey through the world of optimization, research software engineering, and the vibrant Julia community.
+In this episode, Abel covers:
 
-## From Brazil to the Netherlands: A Journey in Research Software Engineering
+- His transition from academia in Brazil to research software engineering in the Netherlands
+- Why he chose Julia for scientific computing and optimization
+- The design and goals of [Julia Smooth Optimizers](https://jso.dev/)
+- Managing interdependent packages and the importance of automation in testing and documentation
+- His contributions to the Julia community through [YouTube](https://www.youtube.com/AbelSiqueira) and open collaboration
 
-Abel shares his fascinating transition from academia in Brazil to becoming a research software engineer at the [Netherlands eScience Center](https://www.esciencecenter.nl/), where he collaborates with researchers to develop cutting-edge software solutions.
-It's a testament to how JuliaSmoothOptimizers is making waves in the international scientific computing landscape.
-
-## Why Julia? Speed, Elegance, and Community
-
-Ever wondered why Julia is the language of choice for JSO? Abel dives deep into his reasons for choosing Julia—from its impressive package ecosystem to its blazing speed.
-His early adoption and advocacy of Julia showcase the language's potential for transforming how we approach computational mathematics and optimization problems.
-
-## JuliaSmoothOptimizers: Tackling Non-Linear Optimization Head-On
-
-The conversation explores [Julia Smooth Optimizers](https://jso.dev/) and its utility in solving complex non-linear optimization problems.
-Abel explains how JSO is more than just a collection of packages—it's a comprehensive ecosystem designed to make optimization accessible, efficient, and powerful.
-
-## The Art of Package Maintenance: Interdependence and Automation
-
-Managing multiple interdependent packages isn't easy, but Abel shares his insights into the orchestration behind JSO.
-From the importance of benchmarking in development to the crucial role of automation in testing and documentation, this episode reveals the careful engineering that keeps JSO running smoothly.
-
-## Community Engagement: YouTube, Collaboration, and Beyond
-
-Abel's commitment to the Julia community extends beyond code.
-He discusses his contributions through his [YouTube channel](https://www.youtube.com/AbelSiqueira) and expresses his enthusiasm for collaborating on both academic and industrial projects.
-It's this spirit of openness and collaboration that makes the JuliaSmoothOptimizers community thrive.
-
-## Tune In: Where Computing Meets the Real World
-
-The Inspiring Computing podcast is where computing meets the real world, featuring proficient users of MATLAB, Python, and Julia who use these tools to deepen their understanding, simulate complex scenarios, and gain valuable insights.
-
-Ready to go behind the code? [Listen to the full episode](https://www.buzzsprout.com/2107763/15200323) and discover the passion, expertise, and vision driving JuliaSmoothOptimizers forward!
-
-## Community Recognition: Celebrating Our Contributors
-
-As we celebrate this milestone, we're reminded that JuliaSmoothOptimizers isn't just about software—it's about the incredible people who make it possible.
-Thank you, Abel, for your dedication, your expertise, and for sharing the JSO story with the world!
-
-*Cheers to JuliaSmoothOptimizers and the Power of Community!* 🚀🎙️✨
+You can listen to the full episode and read the detailed show notes on Buzzsprout: [Behind the Code: Abel's Contributions to Julia Smooth Optimizers and Research Software Engineering](https://www.buzzsprout.com/2107763/episodes/15200323)


### PR DESCRIPTION
The file follows the same format as the existing blogposts in the repository and includes:

- Metadata with title and RSS description
- Main heading with the episode title
- Introduction explaining what the podcast is about
- Episode highlights covering the key topics discussed by Abel
- Information about the podcast
- Link to listen to the full episode
- Closing remarks thanking Abel for his contributions

The blogpost is dated June 14, 2024 (using the date from when the issue was created), which aligns with the podcast publication date of June 6, 2024.

Closes #192 